### PR TITLE
ISPN-6634 Cassandra Cachestore: Upgrade to Infinispan 9.x Snapshot an…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
    <parent>
       <groupId>org.infinispan</groupId>
       <artifactId>infinispan-persistence-parent</artifactId>
-      <version>8.2.2-SNAPSHOT</version>
+      <version>9.0.0-SNAPSHOT</version>
    </parent>
    <artifactId>infinispan-cachestore-cassandra</artifactId>
    <packaging>bundle</packaging>
@@ -43,7 +43,7 @@
       <dependency>
          <groupId>com.datastax.cassandra</groupId>
          <artifactId>cassandra-driver-core</artifactId>
-         <version>3.0.0-rc1</version>
+         <version>3.0.1</version>
       </dependency>
 
        <dependency>

--- a/src/main/java/org/infinispan/persistence/cassandra/configuration/CassandraStoreConfigurationParser82.java
+++ b/src/main/java/org/infinispan/persistence/cassandra/configuration/CassandraStoreConfigurationParser82.java
@@ -8,7 +8,7 @@ import org.infinispan.configuration.parsing.ConfigurationParser;
 import org.infinispan.configuration.parsing.Namespace;
 import org.infinispan.configuration.parsing.Namespaces;
 import org.infinispan.configuration.parsing.ParseUtils;
-import org.infinispan.configuration.parsing.Parser80;
+import org.infinispan.configuration.parsing.Parser;
 import org.infinispan.configuration.parsing.XMLExtendedStreamReader;
 import org.kohsuke.MetaInfServices;
 
@@ -67,7 +67,7 @@ public class CassandraStoreConfigurationParser82 implements ConfigurationParser 
                break;
             }
             default: {
-               Parser80.parseStoreElement(reader, builder);
+               Parser.parseStoreElement(reader, builder);
                break;
             }
          }
@@ -145,7 +145,7 @@ public class CassandraStoreConfigurationParser82 implements ConfigurationParser 
                builder.serialConsistencyLevel(ConsistencyLevel.valueOf(value));
                break;
             default: {
-               Parser80.parseStoreAttribute(reader, i, builder);
+               Parser.parseStoreAttribute(reader, i, builder);
                break;
             }
          }


### PR DESCRIPTION
…d upgrade Cassandra driver to 3.0.x

Hi,

This PR is related to: https://issues.jboss.org/browse/ISPN-6634

Thanks,
Andrea

