### PR TITLE
ISPN-14191 Release cachestore-cassandra

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,73 @@
+name: Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: "The Cassandra cachestore branch to checkout when cutting the release."
+        required: true
+        default: "main"
+      version:
+        description: "Release version"
+        required: true
+      nextVersion:
+        description: "Next version"
+        required: true
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout Source
+        uses: actions/checkout@v2
+        with:
+          ref: ${{ github.event.inputs.branch }}
+
+      - name: Set release version
+        run: mvn -B versions:update-parent "-DparentVersion=[${{ github.event.inputs.version }}]" -DprocessAllModules=true
+      - name: Set up Java for publishing to OSSRH
+        uses: actions/setup-java@v3
+        with:
+          java-version: '11'
+          distribution: 'temurin'
+          server-id: ossrh
+          server-username: MAVEN_USERNAME
+          server-password: MAVEN_PASSWORD
+          gpg-private-key: ${{ secrets.INFINISPAN_MAVEN_GPG_ARMORED }}
+          gpg-passphrase: MAVEN_GPG_PASSPHRASE
+
+      - name: Publish to OSSRH
+        run: mvn -B clean deploy -DskipTests
+        env:
+          MAVEN_USERNAME: ${{ secrets.OSSRH_USERNAME }}
+          MAVEN_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}
+          MAVEN_GPG_PASSPHRASE: ${{ secrets.INFINISPAN_MAVEN_GPG_PASSPHRASE }}
+
+      - name: Configure Git User
+        run: |
+          git config user.email "infinispan@infinispan.org"
+          git config user.name "Infinispan"
+      - name: Tag Release
+        run: |
+          git commit -a -m "Releasing ${{ github.event.inputs.version }}"
+          git tag ${{ github.event.inputs.version }}
+      - name: Next Version
+        run: |
+          mvn -B versions:update-parent "-DparentVersion=[${{ github.event.inputs.nextVersion }}]" -DprocessAllModules=true
+          git commit -a -m "Next version ${{ github.event.inputs.nextVersion }}"
+      - name: Push changes
+        uses: ad-m/github-push-action@master
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          branch: ${{ github.event.inputs.branch }}
+          tags: true
+
+      - id: release
+        name: Create Release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ github.event.inputs.version }}
+          release_name: ${{ github.event.inputs.version }}

--- a/pom.xml
+++ b/pom.xml
@@ -76,7 +76,7 @@
    <properties>
       <jboss.releases.repo.url>https://repository.jboss.org/nexus/service/local/staging/deploy/maven2</jboss.releases.repo.url>
       <jboss.snapshots.repo.url>https://repository.jboss.org/nexus/content/repositories/snapshots</jboss.snapshots.repo.url>
-      <version.infinispan>13.0.10.Final</version.infinispan>
+      <version.infinispan>${project.parent.version}</version.infinispan>
       <version.cassandra>4.14.1</version.cassandra>
       <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
       <maven.compiler.source>11</maven.compiler.source>


### PR DESCRIPTION
https://issues.redhat.com/browse/ISPN-14191

Small change on pom to use `version.infinispan` pinned as the parent version. So the GH actions that update versions update the parent version instead.